### PR TITLE
updated @mixin keyframes to correctly output animation name

### DIFF
--- a/_properties.scss
+++ b/_properties.scss
@@ -80,23 +80,23 @@ $visibilityDefault: hidden !default;
 }
 
 @mixin keyframes($animation-name) {
-  @-webkit-keyframes $animation-name {
+  @-webkit-keyframes #{$animation-name} {
     @content;
   }
 
-  @-moz-keyframes $animation-name {
-    @content;
-  }
-  
-  @-ms-keyframes $animation-name {
-    @content;
-  }
-  
-  @-o-keyframes $animation-name {
+  @-moz-keyframes #{$animation-name} {
     @content;
   }
 
-  @keyframes $animation-name {
+  @-ms-keyframes #{$animation-name} {
+    @content;
+  }
+
+  @-o-keyframes #{$animation-name} {
+    @content;
+  }
+
+  @keyframes #{$animation-name} {
     @content;
   }
 }


### PR DESCRIPTION
In current version it's outputting something like this in the CSS (using Sass v3.4.6):

```
@-webkit-keyframes $animation-name {...}
```
