### PR TITLE
Added animation-iteration-count property

### DIFF
--- a/_attention/_bounce.scss
+++ b/_attention/_bounce.scss
@@ -4,9 +4,10 @@
 	60% {transform: translateY(-15px);}
 }
 
-@mixin bounce($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin bounce($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
 	@include animation-name(bounce);
-  @include duration($duration);
+	@include count($count);
+   @include duration($duration);
 	@include delay($delay);
 	@include function($function);
 	@include fill-mode($fill);

--- a/_attention/_flash.scss
+++ b/_attention/_flash.scss
@@ -3,9 +3,10 @@
 	25%, 75% {opacity: 0;}
 }
 
-@mixin flash($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin flash($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
 	@include animation-name(flash);
-  @include duration($duration);
+	@include count($count);
+   @include duration($duration);
 	@include delay($delay);
 	@include function($function);
 	@include fill-mode($fill);

--- a/_attention/_pulse.scss
+++ b/_attention/_pulse.scss
@@ -6,8 +6,9 @@
   100% {transform: scale(1);}
 }
 
-@mixin pulse($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin pulse($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(pulse);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_attention/_rubberBand.scss
+++ b/_attention/_rubberBand.scss
@@ -28,8 +28,9 @@
   }
 }
 
-@mixin rubberBand($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin rubberBand($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
 	@include animation-name(rubberBand);
+  @include count($count);
   @include duration($duration);
 	@include delay($delay);
 	@include function($function);

--- a/_attention/_shake.scss
+++ b/_attention/_shake.scss
@@ -4,8 +4,9 @@
 	20%, 40%, 60%, 80% {transform: translateX(10px);}
 }
 
-@mixin shake($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin shake($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
 	@include animation-name(shake);
+	@include count($count);
 	@include duration($duration);
 	@include delay($delay);
 	@include function($function);

--- a/_attention/_swing.scss
+++ b/_attention/_swing.scss
@@ -7,9 +7,10 @@
 	100% { -webkit-transform: rotate(0deg); }
 }
 
-@mixin swing($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
-	@include transform-origin(top center);
-	@include animation-name(swing);
+@mixin swing($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+  @include transform-origin(top center);
+  @include animation-name(swing);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_attention/_tada.scss
+++ b/_attention/_tada.scss
@@ -6,9 +6,10 @@
 	100% {-webkit-transform: scale(1) rotate(0);}
 }
 
-@mixin tada($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin tada($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
 	@include animation-name(tada);
-  @include duration($duration);
+	@include count($count);
+   @include duration($duration);
 	@include delay($delay);
 	@include function($function);
 	@include fill-mode($fill);

--- a/_attention/_wobble.scss
+++ b/_attention/_wobble.scss
@@ -10,8 +10,9 @@
   100% {-webkit-transform: translateX(0%);}
 }
 
-@mixin wobble($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin wobble($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
 	@include animation-name(wobble);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_bouncing-entrances/_bounceIn.scss
+++ b/_bouncing-entrances/_bounceIn.scss
@@ -5,8 +5,9 @@
   100% {-webkit-transform: scale(1);}
 }
 
-@mixin bounceIn($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin bounceIn($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(bounceIn);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_bouncing-entrances/_bounceInDown.scss
+++ b/_bouncing-entrances/_bounceInDown.scss
@@ -5,8 +5,9 @@
   100% {-webkit-transform: translateY(0);}
 }
 
-@mixin bounceInDown($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin bounceInDown($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(bounceInDown);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_bouncing-entrances/_bounceInLeft.scss
+++ b/_bouncing-entrances/_bounceInLeft.scss
@@ -5,8 +5,9 @@
   100% {-webkit-transform: translateX(0);}
 }
 
-@mixin bounceInLeft($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin bounceInLeft($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(bounceInLeft);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_bouncing-entrances/_bounceInRight.scss
+++ b/_bouncing-entrances/_bounceInRight.scss
@@ -5,8 +5,9 @@
   100% {-webkit-transform: translateX(0);}
 }
 
-@mixin bounceInRight($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin bounceInRight($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(bounceInRight);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_bouncing-entrances/_bounceInUp.scss
+++ b/_bouncing-entrances/_bounceInUp.scss
@@ -5,8 +5,9 @@
   100% {-webkit-transform: translateY(0);}
 }
 
-@mixin bounceInUp($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin bounceInUp($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(bounceInUp);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_bouncing-exits/_bounceOut.scss
+++ b/_bouncing-exits/_bounceOut.scss
@@ -5,8 +5,9 @@
   100% {opacity: 0; -webkit-transform: scale(.3);}
 }
 
-@mixin bounceOut($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin bounceOut($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(bounceOut);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_bouncing-exits/_bounceOutDown.scss
+++ b/_bouncing-exits/_bounceOutDown.scss
@@ -4,8 +4,9 @@
   100% {opacity: 0; -webkit-transform: translateY(2000px);}
 }
 
-@mixin bounceOutDown($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin bounceOutDown($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(bounceOutDown);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_bouncing-exits/_bounceOutLeft.scss
+++ b/_bouncing-exits/_bounceOutLeft.scss
@@ -4,8 +4,9 @@
   100% {opacity: 0; -webkit-transform: translateX(-2000px);}
 }
 
-@mixin bounceOutLeft($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin bounceOutLeft($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(bounceOutLeft);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_bouncing-exits/_bounceOutRight.scss
+++ b/_bouncing-exits/_bounceOutRight.scss
@@ -4,8 +4,9 @@
   100% {opacity: 0; -webkit-transform: translateX(2000px);}
 }
 
-@mixin bounceOutRight($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin bounceOutRight($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(bounceOutRight);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_bouncing-exits/_bounceOutUp.scss
+++ b/_bouncing-exits/_bounceOutUp.scss
@@ -4,9 +4,10 @@
 	100% {opacity: 0; -webkit-transform: translateY(-2000px);}
 }
 
-@mixin bounceOutUp($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin bounceOutUp($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
 	@include animation-name(bounceOutUp);
-  @include duration($duration);
+	@include count($count);
+   @include duration($duration);
 	@include delay($delay);
 	@include function($function);
 	@include fill-mode($fill);

--- a/_fading-entrances/_fadeIn.scss
+++ b/_fading-entrances/_fadeIn.scss
@@ -3,9 +3,10 @@
 	100% {opacity: 1;}
 }
 
-@mixin fadeIn($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin fadeIn($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
 	@include animation-name(fadeIn);
-  @include duration($duration);
+	@include count($count);
+   @include duration($duration);
 	@include delay($delay);
 	@include function($function);
 	@include fill-mode($fill);

--- a/_fading-entrances/_fadeInDown.scss
+++ b/_fading-entrances/_fadeInDown.scss
@@ -3,8 +3,9 @@
   100% {opacity: 1; -webkit-transform: translateY(0);}
 }
 
-@mixin fadeInDown($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin fadeInDown($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(fadeInDown);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_fading-entrances/_fadeInDownBig.scss
+++ b/_fading-entrances/_fadeInDownBig.scss
@@ -3,8 +3,9 @@
   100% {opacity: 1; -webkit-transform: translateY(0);}
 }
 
-@mixin fadeInDownBig($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin fadeInDownBig($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(fadeInDownBig);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_fading-entrances/_fadeInLeft.scss
+++ b/_fading-entrances/_fadeInLeft.scss
@@ -3,8 +3,9 @@
   100% {opacity: 1; -webkit-transform: translateX(0);}
 }
 
-@mixin fadeInLeft($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin fadeInLeft($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(fadeInLeft);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_fading-entrances/_fadeInLeftBig.scss
+++ b/_fading-entrances/_fadeInLeftBig.scss
@@ -3,8 +3,9 @@
   100% {opacity: 1; transform: translateX(0);}
 }
 
-@mixin fadeInLeftBig($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin fadeInLeftBig($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(fadeInLeftBig);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_fading-entrances/_fadeInRight.scss
+++ b/_fading-entrances/_fadeInRight.scss
@@ -3,8 +3,9 @@
   100% {opacity: 1; transform: translateX(0);}
 }
 
-@mixin fadeInRight($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin fadeInRight($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(fadeInRight);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_fading-entrances/_fadeInRightBig.scss
+++ b/_fading-entrances/_fadeInRightBig.scss
@@ -3,8 +3,9 @@
   100% {opacity: 1; transform: translateX(0);}
 }
 
-@mixin fadeInRightBig($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin fadeInRightBig($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(fadeInRightBig);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_fading-entrances/_fadeInUp.scss
+++ b/_fading-entrances/_fadeInUp.scss
@@ -3,8 +3,9 @@
   100% {opacity: 1; transform: translateY(0);}
 }
 
-@mixin fadeInUp($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin fadeInUp($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(fadeInUp);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_fading-entrances/_fadeInUpBig.scss
+++ b/_fading-entrances/_fadeInUpBig.scss
@@ -3,8 +3,9 @@
   100% {opacity: 1; transform: translateY(0);}
 }
 
-@mixin fadeInUpBig($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin fadeInUpBig($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(fadeInUpBig);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_fading-exits/_fadeOut.scss
+++ b/_fading-exits/_fadeOut.scss
@@ -3,8 +3,9 @@
 	100% {opacity: 0;}
 }
 
-@mixin fadeOut($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin fadeOut($count: $coutnDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
 	@include animation-name(fadeOut);
+	@include count($count);
 	@include duration($duration);
 	@include delay($delay);
 	@include function($function);

--- a/_fading-exits/_fadeOutDown.scss
+++ b/_fading-exits/_fadeOutDown.scss
@@ -3,8 +3,9 @@
   100% {opacity: 0; transform: translateY(20px);}
 }
 
-@mixin fadeOutDown($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin fadeOutDown($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(fadeOutDown);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_fading-exits/_fadeOutDownBig.scss
+++ b/_fading-exits/_fadeOutDownBig.scss
@@ -3,8 +3,9 @@
   100% {opacity: 0; transform: translateY(2000px);}
 }
 
-@mixin fadeOutDownBig($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin fadeOutDownBig($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(fadeOutDownBig);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_fading-exits/_fadeOutLeft.scss
+++ b/_fading-exits/_fadeOutLeft.scss
@@ -3,8 +3,9 @@
   100% {opacity: 0; transform: translateX(-20px);}
 }
 
-@mixin fadeOutLeft($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin fadeOutLeft($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(fadeOutLeft);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_fading-exits/_fadeOutLeftBig.scss
+++ b/_fading-exits/_fadeOutLeftBig.scss
@@ -3,8 +3,9 @@
   100% {opacity: 0; transform: translateX(-2000px);}
 }
 
-@mixin fadeOutLeftBig($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin fadeOutLeftBig($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(fadeOutLeftBig);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_fading-exits/_fadeOutRight.scss
+++ b/_fading-exits/_fadeOutRight.scss
@@ -3,8 +3,9 @@
   100% {opacity: 0; transform: translateX(20px);}
 }
 
-@mixin fadeOutRight($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin fadeOutRight($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(fadeOutRight);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_fading-exits/_fadeOutRightBig.scss
+++ b/_fading-exits/_fadeOutRightBig.scss
@@ -3,8 +3,9 @@
   100% {opacity: 0; transform: translateX(2000px);}
 }
 
-@mixin fadeOutRightBig($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin fadeOutRightBig($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(fadeOutRightBig);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_fading-exits/_fadeOutUp.scss
+++ b/_fading-exits/_fadeOutUp.scss
@@ -3,8 +3,9 @@
   100% {opacity: 0; transform: translateY(-20px);}
 }
 
-@mixin fadeOutUp($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin fadeOutUp($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(fadeOutUp);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_fading-exits/_fadeOutUpBig.scss
+++ b/_fading-exits/_fadeOutUpBig.scss
@@ -3,8 +3,9 @@
   100% {opacity: 0; transform: translateY(-2000px);}
 }
 
-@mixin fadeOutUpBig($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin fadeOutUpBig($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(fadeOutUpBig);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_flippers/_flip.scss
+++ b/_flippers/_flip.scss
@@ -6,9 +6,10 @@
   100% {transform: perspective(400px) scale(1); animation-timing-function: ease-in;}
 }
 
-@mixin flip($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin flip($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include transform-style(preserve-3d);
   @include animation-name(flip);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_flippers/_flipInX.scss
+++ b/_flippers/_flipInX.scss
@@ -5,8 +5,9 @@
   100% {transform: perspective(400px) rotateX(0deg); opacity: 1;}
 }
 
-@mixin flipInX($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin flipInX($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(flipInX);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_flippers/_flipInY.scss
+++ b/_flippers/_flipInY.scss
@@ -5,8 +5,9 @@
   100% {transform: perspective(400px) rotateY(0deg); opacity: 1;}
 }
 
-@mixin flipInY($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin flipInY($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(flipInY);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_flippers/_flipOutX.scss
+++ b/_flippers/_flipOutX.scss
@@ -3,8 +3,9 @@
   100% {transform: perspective(400px) rotateX(90deg); opacity: 0;}
 }
 
-@mixin flipOutX($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin flipOutX($count: $countDefult, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(flipOutX);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_flippers/_flipOutY.scss
+++ b/_flippers/_flipOutY.scss
@@ -3,8 +3,9 @@
   100% {transform: perspective(400px) rotateY(90deg); opacity: 0;}
 }
 
-@mixin flipOutY($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin flipOutY($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(flipOutY);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_lightspeed/_lightSpeedIn.scss
+++ b/_lightspeed/_lightSpeedIn.scss
@@ -5,8 +5,9 @@
 	100% { transform: translateX(0%) skewX(0deg); opacity: 1;}
 }
 
-@mixin lightSpeedIn($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin lightSpeedIn($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(lightSpeedIn);
+  @include count($count);
 	@include function(ease-out);
   @include duration($duration);
   @include delay($delay);

--- a/_lightspeed/_lightSpeedOut.scss
+++ b/_lightspeed/_lightSpeedOut.scss
@@ -3,8 +3,9 @@
   100% { transform: translateX(100%) skewX(-30deg); opacity: 0;}
 }
 
-@mixin lightSpeedOut($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin lightSpeedOut($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(lightSpeedOut);
+  @include count($count);
   @include function(ease-in);
   @include duration($duration);
   @include delay($delay);

--- a/_properties.scss
+++ b/_properties.scss
@@ -10,18 +10,27 @@
 //
 // visibility   Determines whether or not a transformed element is visible when it is not facing the screen.
 
+$countDefault: 1s !default;
 $durationDefault: 1s !default;
 $delayDefault: 0s !default;
 $functionDefault: ease !default;
 $fillDefault: both;
 $visibilityDefault: hidden !default;
 
+@mixin count($count: 1) {
+  -webkit-animation-iteration-count: $count;
+     -moz-animation-iteration-count: $count;
+      -ms-animation-iteration-count: $count;
+       -o-animation-iteration-count: $count;
+          animation-iteration-count: $count;
+}
+
 @mixin duration($duration: 1s) {
   -webkit-animation-duration: $duration;
      -moz-animation-duration: $duration;
-       -ms-animation-duration: $duration;
-        -o-animation-duration: $duration;
-           animation-duration: $duration;
+      -ms-animation-duration: $duration;
+       -o-animation-duration: $duration;
+          animation-duration: $duration;
 }
 
 @mixin delay($delay: .2s) {

--- a/_rotating-entrances/_rotateIn.scss
+++ b/_rotating-entrances/_rotateIn.scss
@@ -3,8 +3,9 @@
   100% {transform-origin: center center; transform: rotate(0); opacity: 1;}
 }
 
-@mixin rotateIn($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin rotateIn($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(rotateIn);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_rotating-entrances/_rotateInDownLeft.scss
+++ b/_rotating-entrances/_rotateInDownLeft.scss
@@ -3,8 +3,9 @@
   100% {transform-origin: left bottom; transform: rotate(0); opacity: 1;}
 }
 
-@mixin rotateInDownLeft($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin rotateInDownLeft($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(rotateInDownLeft);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_rotating-entrances/_rotateInDownRight.scss
+++ b/_rotating-entrances/_rotateInDownRight.scss
@@ -3,8 +3,9 @@
   100% {transform-origin: right bottom; transform: rotate(0); opacity: 1;}
 }
 
-@mixin rotateInDownRight($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin rotateInDownRight($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(rotateInDownRight);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_rotating-entrances/_rotateInUpLeft.scss
+++ b/_rotating-entrances/_rotateInUpLeft.scss
@@ -3,8 +3,9 @@
   100% {transform-origin: left bottom; transform: rotate(0); opacity: 1;}
 }
 
-@mixin rotateInUpLeft($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin rotateInUpLeft($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(rotateInUpLeft);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_rotating-entrances/_rotateInUpRight.scss
+++ b/_rotating-entrances/_rotateInUpRight.scss
@@ -3,8 +3,9 @@
   100% {transform-origin: right bottom; transform: rotate(0); opacity: 1;}
 }
 
-@mixin rotateInUpRight($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin rotateInUpRight($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(rotateInUpRight);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_rotating-exits/_rotateOut.scss
+++ b/_rotating-exits/_rotateOut.scss
@@ -3,8 +3,9 @@
 	100% {transform-origin: center center; transform: rotate(200deg); opacity: 0;}
 }
 
-@mixin rotateOut($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
-	@include animation-name(rotateOut);
+@mixin rotateOut($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+  @include animation-name(rotateOut);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_rotating-exits/_rotateOutDownLeft.scss
+++ b/_rotating-exits/_rotateOutDownLeft.scss
@@ -3,8 +3,9 @@
 	100% {transform-origin: left bottom; transform: rotate(90deg); opacity: 0;}
 }
 
-@mixin rotateOutDownLeft($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
-	@include animation-name(rotateOutDownLeft);
+@mixin rotateOutDownLeft($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+  @include animation-name(rotateOutDownLeft);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_rotating-exits/_rotateOutDownRight.scss
+++ b/_rotating-exits/_rotateOutDownRight.scss
@@ -3,8 +3,9 @@
 	100% {transform-origin: right bottom; transform: rotate(-90deg); opacity: 0;}
 }
 
-@mixin rotateOutDownRight($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
-	@include animation-name(rotateOutDownRight);
+@mixin rotateOutDownRight($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+  @include animation-name(rotateOutDownRight);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_rotating-exits/_rotateOutUpLeft.scss
+++ b/_rotating-exits/_rotateOutUpLeft.scss
@@ -3,8 +3,9 @@
  100% {transform-origin: left bottom; transform: rotate(-90deg); opacity: 0;}
 }
 
-@mixin rotateOutUpLeft($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
-	@include animation-name(rotateOutUpLeft);
+@mixin rotateOutUpLeft($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+  @include animation-name(rotateOutUpLeft);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_rotating-exits/_rotateOutUpRight.scss
+++ b/_rotating-exits/_rotateOutUpRight.scss
@@ -3,8 +3,9 @@
   100% {transform-origin: right bottom; transform: rotate(90deg); opacity: 0;}
 }
 
-@mixin rotateOutUpRight($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin rotateOutUpRight($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(rotateOutUpRight);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_sliders/_slideInDown.scss
+++ b/_sliders/_slideInDown.scss
@@ -3,8 +3,9 @@
 	100% {transform: translateY(0);}
 }
 
-@mixin slideInDown($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
-	@include animation-name(slideInDown);
+@mixin slideInDown($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+  @include animation-name(slideInDown);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_sliders/_slideInLeft.scss
+++ b/_sliders/_slideInLeft.scss
@@ -3,8 +3,9 @@
 	100% {transform: translateX(0);}
 }
 
-@mixin slideInLeft($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
-	@include animation-name(slideInLeft);
+@mixin slideInLeft($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+  @include animation-name(slideInLeft);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_sliders/_slideInRight.scss
+++ b/_sliders/_slideInRight.scss
@@ -3,8 +3,9 @@
 	100% {transform: translateX(0);}
 }
 
-@mixin slideInRight($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
-	@include animation-name(slideInRight);
+@mixin slideInRight($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+  @include animation-name(slideInRight);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_sliders/_slideInUp.scss
+++ b/_sliders/_slideInUp.scss
@@ -3,8 +3,9 @@
 	100% {transform: translateY(0);}
 }
 
-@mixin slideInUp($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
-	@include animation-name(slideInUp);
+@mixin slideInUp($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+  @include animation-name(slideInUp);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_sliders/_slideOutDown.scss
+++ b/_sliders/_slideOutDown.scss
@@ -3,8 +3,9 @@
 	100% {opacity: 0; transform: translateY(2000px);}
 }
 
-@mixin slideOutDown($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
-	@include animation-name(slideOutDown);
+@mixin slideOutDown($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+  @include animation-name(slideOutDown);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_sliders/_slideOutLeft.scss
+++ b/_sliders/_slideOutLeft.scss
@@ -3,8 +3,9 @@
 	100% {opacity: 0; transform: translateX(-2000px);}
 }
 
-@mixin slideOutLeft($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
-	@include animation-name(slideOutLeft);
+@mixin slideOutLeft($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+  @include animation-name(slideOutLeft);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_sliders/_slideOutRight.scss
+++ b/_sliders/_slideOutRight.scss
@@ -3,8 +3,9 @@
 	100% {opacity: 0; transform: translateX(2000px);}
 }
 
-@mixin slideOutRight($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
-	@include animation-name(slideOutRight);
+@mixin slideOutRight($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+  @include animation-name(slideOutRight);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_sliders/_slideOutUp.scss
+++ b/_sliders/_slideOutUp.scss
@@ -3,8 +3,9 @@
 	100% {opacity: 0; transform: translateY(-2000px);}
 }
 
-@mixin slideOutUp($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
-	@include animation-name(slideOutUp);
+@mixin slideOutUp($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+  @include animation-name(slideOutUp);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_specials/_hinge.scss
+++ b/_specials/_hinge.scss
@@ -26,8 +26,9 @@
   }
 }
 
-@mixin hinge($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin hinge($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(hinge);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_specials/_rollIn.scss
+++ b/_specials/_rollIn.scss
@@ -9,8 +9,9 @@
   }
 }
 
-@mixin rollIn($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin rollIn($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(rollIn);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_specials/_rollOut.scss
+++ b/_specials/_rollOut.scss
@@ -11,8 +11,9 @@
   }
 }
 
-@mixin rollOut($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin rollOut($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(rollOut);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_zooming-entrances/_zoomIn.scss
+++ b/_zooming-entrances/_zoomIn.scss
@@ -8,8 +8,9 @@
   }
 }
 
-@mixin zoomIn($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin zoomIn($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(zoomIn);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_zooming-entrances/_zoomInDown.scss
+++ b/_zooming-entrances/_zoomInDown.scss
@@ -11,8 +11,9 @@
   }
 }
 
-@mixin zoomInDown($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin zoomInDown($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(zoomInDown);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_zooming-entrances/_zoomInLeft.scss
+++ b/_zooming-entrances/_zoomInLeft.scss
@@ -11,8 +11,9 @@
   }
 }
 
-@mixin zoomInLeft($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin zoomInLeft($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(zoomInLeft);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_zooming-entrances/_zoomInRight.scss
+++ b/_zooming-entrances/_zoomInRight.scss
@@ -11,8 +11,9 @@
   }
 }
 
-@mixin zoomInRight($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin zoomInRight($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(zoomInRight);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_zooming-entrances/_zoomInUp.scss
+++ b/_zooming-entrances/_zoomInUp.scss
@@ -11,8 +11,9 @@
   }
 }
 
-@mixin zoomInUp($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin zoomInUp($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(zoomInUp);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_zooming-exits/_zoomOut.scss
+++ b/_zooming-exits/_zoomOut.scss
@@ -11,8 +11,9 @@
   }
 }
 
-@mixin zoomOut($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin zoomOut($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(zoomOut);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_zooming-exits/_zoomOutDown.scss
+++ b/_zooming-exits/_zoomOutDown.scss
@@ -12,8 +12,9 @@
   }
 }
 
-@mixin zoomOutDown($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin zoomOutDown($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(zoomOutDown);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_zooming-exits/_zoomOutLeft.scss
+++ b/_zooming-exits/_zoomOutLeft.scss
@@ -10,8 +10,9 @@
   }
 }
 
-@mixin zoomOutLeft($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin zoomOutLeft($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(zoomOutLeft);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_zooming-exits/_zoomOutRight.scss
+++ b/_zooming-exits/_zoomOutRight.scss
@@ -10,8 +10,9 @@
   }
 }
 
-@mixin zoomOutRight($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin zoomOutRight($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(zoomOutRight);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);

--- a/_zooming-exits/_zoomOutUp.scss
+++ b/_zooming-exits/_zoomOutUp.scss
@@ -12,8 +12,9 @@
   }
 }
 
-@mixin zoomOutUp($duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
+@mixin zoomOutUp($count: $countDefault, $duration: $durationDefault, $delay: $delayDefault, $function: $functionDefault, $fill: $fillDefault, $visibility: $visibilityDefault) {
   @include animation-name(zoomOutUp);
+  @include count($count);
   @include duration($duration);
   @include delay($delay);
   @include function($function);


### PR DESCRIPTION
I updated the animation functions to include $count parameter for setting the animation-iteration-count CSS property (i.e. animation-iteration-count: infinite). I mostly did this so I could get the "flash" animation to repeat indefinitely, but it allows animations to also be repeated any number of times. The default setting is 1.
