### PR TITLE
refactor: retrofit patch for Dart Sass 1.80.0+ compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,24 +24,21 @@ The default import includes all animations.
 Want to pick and choose which animations are imported? Go into animate.scss and comment out what you don't need.
 
 ```
-// Always required
-@import 
-  "_properties";
-
 // Import the animations
-@import 
   // "_attention-seekers/attention-seekers.scss", // This will not import
-  "_bouncing-entrances/bouncing-entrances.scss",
-  "_bouncing-exits/bouncing-exits.scss",
-  "_fading-entrances/fading-entrances.scss",
-  "_fading-exits/fading-exits.scss",
-  "_flippers/flippers.scss",
-  "_lightspeed/lightspeed.scss",
-  "_rotating-entrances/rotating-entrances.scss",
-  "_rotating-exits/rotating-exits.scss",
-  "_specials/specials.scss";
+@use "_bouncing-entrances/bouncing-entrances.scss" as entrances;
+@use "_bouncing-exits/bouncing-exits.scss" as *;
+@use "_fading-entrances/fading-entrances.scss" as *;
+@use "_fading-exits/fading-exits.scss" as *;
+@use "_flippers/flippers.scss" as *;
+@use "_lightspeed/lightspeed.scss" as *;
+@use "_rotating-entrances/rotating-entrances.scss" as *;
+@use "_rotating-exits/rotating-exits.scss" as *;
+@use "_specials/specials.scss" as *;
 ```
-You only want one of two of the animations? You can `@import` the specific partials in animate.scss instead (Example: `@import "_attention-seekers/_bounce";`).
+You only want one of two of the animations? You can `@use` the mixins specific
+    to partials in animate.scss instead (Example: `@use "_attention-seekers/bounce" as *;`) 
+    and `@forward` `properties` to export the referenced keyframes.
 
 ## Usage
 

--- a/_attention-seekers/_bounce.scss
+++ b/_attention-seekers/_bounce.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(bounce) {
 	0%, 20%, 50%, 80%, 100% {@include transform(translateY(0));}
 	40% {@include transform(translateY(-30px));}

--- a/_attention-seekers/_flash.scss
+++ b/_attention-seekers/_flash.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(flash) {
 	0%, 50%, 100% {opacity: 1;}
 	25%, 75% {opacity: 0;}

--- a/_attention-seekers/_jello.scss
+++ b/_attention-seekers/_jello.scss
@@ -1,4 +1,5 @@
 // originally authored by Nick Pettit - https://github.com/nickpettit/glide
+@use '../properties' as *;
 
 @include keyframes(jello) {
   11.1% {@include transform(none);}

--- a/_attention-seekers/_pulse.scss
+++ b/_attention-seekers/_pulse.scss
@@ -1,4 +1,5 @@
 // originally authored by Nick Pettit - https://github.com/nickpettit/glide
+@use '../properties' as *;
 
 @include keyframes(pulse) {
 	  0% {@include transform(scale(1));}

--- a/_attention-seekers/_rubberBand.scss
+++ b/_attention-seekers/_rubberBand.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(rubberBand) {
 	  0% {@include transform(scale3d(1, 1, 1));}
    30% {@include transform(scale3d(1.25, 0.75, 1));}

--- a/_attention-seekers/_shake.scss
+++ b/_attention-seekers/_shake.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(shake) {
   0%, 100% {@include transform(translateX(0));}
 	10%, 30%, 50%, 70%, 90% {@include transform(translateX(-10px));}

--- a/_attention-seekers/_swing.scss
+++ b/_attention-seekers/_swing.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(swing) {
 	20%, 40%, 60%, 80%, 100% {@include transform-origin(top center);}
 	20% {@include transform(rotate(15deg));}

--- a/_attention-seekers/_tada.scss
+++ b/_attention-seekers/_tada.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(tada) {
 	0% {@include transform(scale(1));}
 	10%, 20% {@include transform(scale(0.9) rotate(-3deg));}

--- a/_attention-seekers/_wobble.scss
+++ b/_attention-seekers/_wobble.scss
@@ -1,4 +1,5 @@
 // originally authored by Nick Pettit - https://github.com/nickpettit/glide
+@use '../properties' as *;
 
 @include keyframes(wobble) {
     0% {@include transform(translateX(0%));}

--- a/_attention-seekers/attention-seekers.scss
+++ b/_attention-seekers/attention-seekers.scss
@@ -1,13 +1,13 @@
 // INDEX OF ATTENTION SEEKERS
 
-@import 
-  "_bounce",
-  "_flash",
-  "_jello",
-  "_pulse",
-  "_rubberBand",
-  "_shake",
-  "_swing",
-  "_tada",
-  "_wobble";
-  
+
+@forward "bounce";
+@forward "flash";
+@forward "jello";
+@forward "pulse";
+@forward "rubberBand";
+@forward "shake";
+@forward "swing";
+@forward "tada";
+@forward "wobble";
+

--- a/_bouncing-entrances/_bounceIn.scss
+++ b/_bouncing-entrances/_bounceIn.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(bounceIn) {
   0% {
     opacity: 0;

--- a/_bouncing-entrances/_bounceInDown.scss
+++ b/_bouncing-entrances/_bounceInDown.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(bounceInDown) {
   0% {
     opacity: 0;

--- a/_bouncing-entrances/_bounceInLeft.scss
+++ b/_bouncing-entrances/_bounceInLeft.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(bounceInLeft) {
   0% {
     opacity: 0;

--- a/_bouncing-entrances/_bounceInRight.scss
+++ b/_bouncing-entrances/_bounceInRight.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(bounceInRight) {
   0% {
     opacity: 0;

--- a/_bouncing-entrances/_bounceInUp.scss
+++ b/_bouncing-entrances/_bounceInUp.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(bounceInUp) {
   0% {
     opacity: 0;

--- a/_bouncing-entrances/bouncing-entrances.scss
+++ b/_bouncing-entrances/bouncing-entrances.scss
@@ -1,9 +1,8 @@
 // INDEX OF BOUNCING ENTRANCES
 
-@import
-  "_bounceIn",
-  "_bounceInDown",
-  "_bounceInLeft",
-  "_bounceInRight",
-  "_bounceInUp";
+@forward "bounceIn";
+@forward "bounceInDown";
+@forward "bounceInLeft";
+@forward "bounceInRight";
+@forward "bounceInUp";
   

--- a/_bouncing-exits/_bounceOut.scss
+++ b/_bouncing-exits/_bounceOut.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(bounceOut) {
   0% {
     @include transform(scale(1));

--- a/_bouncing-exits/_bounceOutDown.scss
+++ b/_bouncing-exits/_bounceOutDown.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(bounceOutDown) {
   0% {
     @include transform(translateY(0));

--- a/_bouncing-exits/_bounceOutLeft.scss
+++ b/_bouncing-exits/_bounceOutLeft.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(bounceOutLeft) {
     0% {
       @include transform(translateX(0));

--- a/_bouncing-exits/_bounceOutRight.scss
+++ b/_bouncing-exits/_bounceOutRight.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(bounceOutRight) {
     0% {
       @include transform(translateX(0));

--- a/_bouncing-exits/_bounceOutUp.scss
+++ b/_bouncing-exits/_bounceOutUp.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(bounceOutUp) {
   0% {
 	  @include transform(translateY(0));

--- a/_bouncing-exits/bouncing-exits.scss
+++ b/_bouncing-exits/bouncing-exits.scss
@@ -1,9 +1,8 @@
 // INDEX OF BOUNCING EXITS
 
-@import 
-  "_bounceOut",
-  "_bounceOutDown",
-  "_bounceOutLeft",
-  "_bounceOutRight",
-  "_bounceOutUp";
+@forward "bounceOut";
+@forward "bounceOutDown";
+@forward "bounceOutLeft";
+@forward "bounceOutRight";
+@forward "bounceOutUp";
   

--- a/_fading-entrances/_fadeIn.scss
+++ b/_fading-entrances/_fadeIn.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(fadeIn) {
 	  0% {opacity: 0;}
 	100% {opacity: 1;}

--- a/_fading-entrances/_fadeInDown.scss
+++ b/_fading-entrances/_fadeInDown.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(fadeInDown) {
   0% {
     opacity: 0;

--- a/_fading-entrances/_fadeInDownBig.scss
+++ b/_fading-entrances/_fadeInDownBig.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(fadeInDownBig) {
   0% {
     opacity: 0;

--- a/_fading-entrances/_fadeInLeft.scss
+++ b/_fading-entrances/_fadeInLeft.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(fadeInLeft) {
   0% {
     opacity: 0;

--- a/_fading-entrances/_fadeInLeftBig.scss
+++ b/_fading-entrances/_fadeInLeftBig.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(fadeInLeftBig) {
   0% {
     opacity: 0;

--- a/_fading-entrances/_fadeInRight.scss
+++ b/_fading-entrances/_fadeInRight.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(fadeInRight) {
   0% {
     opacity: 0;

--- a/_fading-entrances/_fadeInRightBig.scss
+++ b/_fading-entrances/_fadeInRightBig.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(fadeInRightBig) {
   0% {
     opacity: 0;

--- a/_fading-entrances/_fadeInUp.scss
+++ b/_fading-entrances/_fadeInUp.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(fadeInUp) {
   0% {
     opacity: 0;

--- a/_fading-entrances/_fadeInUpBig.scss
+++ b/_fading-entrances/_fadeInUpBig.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(fadeInUpBig) {
   0% {
     opacity: 0;

--- a/_fading-entrances/fading-entrances.scss
+++ b/_fading-entrances/fading-entrances.scss
@@ -1,13 +1,12 @@
 // INDEX OF FADING ENTRANCES
 
-@import 
-  "_fadeIn",
-  "_fadeInDown",
-  "_fadeInDownBig",
-  "_fadeInLeft",
-  "_fadeInLeftBig",
-  "_fadeInRight",
-  "_fadeInRightBig",
-  "_fadeInUp",
-  "_fadeInUpBig";
+@forward "fadeIn";
+@forward "fadeInDown";
+@forward "fadeInDownBig";
+@forward "fadeInLeft";
+@forward "fadeInLeftBig";
+@forward "fadeInRight";
+@forward "fadeInRightBig";
+@forward "fadeInUp";
+@forward "fadeInUpBig";
   

--- a/_fading-exits/_fadeOut.scss
+++ b/_fading-exits/_fadeOut.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(fadeOut) {
 	  0% {opacity: 1;}
 	100% {opacity: 0;}

--- a/_fading-exits/_fadeOutDown.scss
+++ b/_fading-exits/_fadeOutDown.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(fadeOutDown) {
   0% {
     opacity: 1;

--- a/_fading-exits/_fadeOutDownBig.scss
+++ b/_fading-exits/_fadeOutDownBig.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(fadeOutDownBig) {
   0% {
     opacity: 1;

--- a/_fading-exits/_fadeOutLeft.scss
+++ b/_fading-exits/_fadeOutLeft.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(fadeOutLeft) {
   0% {
     opacity: 1;

--- a/_fading-exits/_fadeOutLeftBig.scss
+++ b/_fading-exits/_fadeOutLeftBig.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(fadeOutLeftBig) {
   0% {
     opacity: 1;

--- a/_fading-exits/_fadeOutRight.scss
+++ b/_fading-exits/_fadeOutRight.scss
@@ -1,4 +1,7 @@
+@use '../properties' as *;
+
 @include keyframes(fadeOutRight) {
+
   0% {
     opacity: 1;
     @include transform(translateX(0));

--- a/_fading-exits/_fadeOutRightBig.scss
+++ b/_fading-exits/_fadeOutRightBig.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(fadeOutRightBig) {
   0% {
     opacity: 1;

--- a/_fading-exits/_fadeOutUp.scss
+++ b/_fading-exits/_fadeOutUp.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(fadeOutUp) {
   0% {
     opacity: 1;

--- a/_fading-exits/_fadeOutUpBig.scss
+++ b/_fading-exits/_fadeOutUpBig.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(fadeOutUpBig) {
   0% {
     opacity: 1;

--- a/_fading-exits/fading-exits.scss
+++ b/_fading-exits/fading-exits.scss
@@ -1,13 +1,12 @@
 // INDEX OF FADING EXITS
 
-@import 
-  "_fadeOut",
-  "_fadeOutDown",
-  "_fadeOutDownBig",
-  "_fadeOutLeft",
-  "_fadeOutLeftBig",
-  "_fadeOutRight",
-  "_fadeOutRightBig",
-  "_fadeOutUp",
-  "_fadeOutUpBig";
+@forward "fadeOut";
+@forward "fadeOutDown";
+@forward "fadeOutDownBig";
+@forward "fadeOutLeft";
+@forward "fadeOutLeftBig";
+@forward "fadeOutRight";
+@forward "fadeOutRightBig";
+@forward "fadeOutUp";
+@forward "fadeOutUpBig";
   

--- a/_flippers/_flip.scss
+++ b/_flippers/_flip.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(flip) {
   0% {
     @include transform(perspective(400px) rotateY(0));

--- a/_flippers/_flipInX.scss
+++ b/_flippers/_flipInX.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(flipInX) {
   0% {
     opacity: 0;

--- a/_flippers/_flipInY.scss
+++ b/_flippers/_flipInY.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(flipInY) {
   0% {
     opacity: 0;

--- a/_flippers/_flipOutX.scss
+++ b/_flippers/_flipOutX.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(flipOutX) {
   0% {
     opacity: 1;

--- a/_flippers/_flipOutY.scss
+++ b/_flippers/_flipOutY.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(flipOutY) {
   0% {
     opacity: 1;

--- a/_flippers/flippers.scss
+++ b/_flippers/flippers.scss
@@ -1,8 +1,7 @@
 // INDEX OF FLIPPERS
 
-@import 
-  "_flip",
-  "_flipInX",
-  "_flipInY",
-  "_flipOutX",
-  "_flipOutY";
+@forward "flip";
+@forward "flipInX";
+@forward "flipInY";
+@forward "flipOutX";
+@forward "flipOutY";

--- a/_lightspeed/_lightSpeedIn.scss
+++ b/_lightspeed/_lightSpeedIn.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(lightSpeedIn) {
 	0% {
   	opacity: 0;

--- a/_lightspeed/_lightSpeedOut.scss
+++ b/_lightspeed/_lightSpeedOut.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(lightSpeedOut) {
   0% {
     opacity: 1;

--- a/_lightspeed/lightspeed.scss
+++ b/_lightspeed/lightspeed.scss
@@ -1,5 +1,4 @@
 // INDEX OF LIGHTSPEED ANIMATIONS
 
-@import 
-  "_lightSpeedIn",
-  "_lightSpeedOut";
+@forward "lightSpeedIn";
+@forward "lightSpeedOut";

--- a/_rotating-entrances/_rotateIn.scss
+++ b/_rotating-entrances/_rotateIn.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(rotateIn) {
   0% {
     opacity: 0;

--- a/_rotating-entrances/_rotateInDownLeft.scss
+++ b/_rotating-entrances/_rotateInDownLeft.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(rotateInDownLeft) {
   0% {
     opacity: 0;

--- a/_rotating-entrances/_rotateInDownRight.scss
+++ b/_rotating-entrances/_rotateInDownRight.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(rotateInDownRight) {
   0% {
     opacity: 0;

--- a/_rotating-entrances/_rotateInUpLeft.scss
+++ b/_rotating-entrances/_rotateInUpLeft.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(rotateInUpLeft) {
   0% {
     opacity: 0;

--- a/_rotating-entrances/_rotateInUpRight.scss
+++ b/_rotating-entrances/_rotateInUpRight.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(rotateInUpRight) {
   0% {
     opacity: 0;

--- a/_rotating-entrances/rotating-entrances.scss
+++ b/_rotating-entrances/rotating-entrances.scss
@@ -1,8 +1,7 @@
 // INDEX OF ROTATING ENTRANCES
 
-@import 
-  "_rotateIn",
-  "_rotateInDownLeft",
-  "_rotateInDownRight",
-  "_rotateInUpLeft",
-  "_rotateInUpRight";
+@forward "rotateIn";
+@forward "rotateInDownLeft";
+@forward "rotateInDownRight";
+@forward "rotateInUpLeft";
+@forward "rotateInUpRight";

--- a/_rotating-exits/_rotateOut.scss
+++ b/_rotating-exits/_rotateOut.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(rotateOut) {
 	0% {
   	opacity: 1;

--- a/_rotating-exits/_rotateOutDownLeft.scss
+++ b/_rotating-exits/_rotateOutDownLeft.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(rotateOutDownLeft) {
 	0% {
   	opacity: 1;

--- a/_rotating-exits/_rotateOutDownRight.scss
+++ b/_rotating-exits/_rotateOutDownRight.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(rotateOutDownRight) {
 	0% {
   	opacity: 1;

--- a/_rotating-exits/_rotateOutUpLeft.scss
+++ b/_rotating-exits/_rotateOutUpLeft.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(rotateOutUpLeft) {
 	0% {
   	opacity: 1;

--- a/_rotating-exits/_rotateOutUpRight.scss
+++ b/_rotating-exits/_rotateOutUpRight.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(rotateOutUpRight) {
   0% {
     opacity: 1;

--- a/_rotating-exits/rotating-exits.scss
+++ b/_rotating-exits/rotating-exits.scss
@@ -1,8 +1,7 @@
 // INDEX OF ROTATING EXITS
 
-@import 
-  "_rotateOut",
-  "_rotateOutDownLeft",
-  "_rotateOutDownRight",
-  "_rotateOutUpLeft",
-  "_rotateOutUpRight";
+@forward "rotateOut";
+@forward "rotateOutDownLeft";
+@forward "rotateOutDownRight";
+@forward "rotateOutUpLeft";
+@forward "rotateOutUpRight";

--- a/_sliding-entrances/_slideInDown.scss
+++ b/_sliding-entrances/_slideInDown.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(slideInDown) {
   0% {
     opacity: 0;

--- a/_sliding-entrances/_slideInLeft.scss
+++ b/_sliding-entrances/_slideInLeft.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(slideInLeft) {
   0% {
     opacity: 0;

--- a/_sliding-entrances/_slideInRight.scss
+++ b/_sliding-entrances/_slideInRight.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(slideInRight) {
   0% {
     opacity: 0;

--- a/_sliding-entrances/_slideInUp.scss
+++ b/_sliding-entrances/_slideInUp.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(slideInUp) {
   0% {
     opacity: 0;

--- a/_sliding-entrances/sliding-entrances.scss
+++ b/_sliding-entrances/sliding-entrances.scss
@@ -1,7 +1,6 @@
 // INDEX OF SLIDING ENTRANCES
 
-@import
-  "_slideInDown",
-  "_slideInLeft",
-  "_slideInRight",
-  "_slideInUp";
+@forward "slideInDown";
+@forward "slideInLeft";
+@forward "slideInRight";
+@forward "slideInUp";

--- a/_sliding-exits/_slideOutDown.scss
+++ b/_sliding-exits/_slideOutDown.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(slideOutDown) {
 	0% {
   	@include transform(translateY(0));

--- a/_sliding-exits/_slideOutLeft.scss
+++ b/_sliding-exits/_slideOutLeft.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(slideOutLeft) {
 	0% {
   	@include transform(translateX(0));

--- a/_sliding-exits/_slideOutRight.scss
+++ b/_sliding-exits/_slideOutRight.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(slideOutRight) {
 	0% {
   	@include transform(translateX(0));

--- a/_sliding-exits/_slideOutUp.scss
+++ b/_sliding-exits/_slideOutUp.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(slideOutUp) {
 	0% {
   	@include transform(translateY(0));

--- a/_sliding-exits/sliding-exits.scss
+++ b/_sliding-exits/sliding-exits.scss
@@ -1,7 +1,6 @@
 // INDEX OF SLIDING EXITS
 
-@import
-  "_slideOutDown",
-  "_slideOutLeft",
-  "_slideOutRight",
-  "_slideOutUp";
+@forward "slideOutDown";
+@forward "slideOutLeft";
+@forward "slideOutRight";
+@forward "slideOutUp";

--- a/_specials/_hinge.scss
+++ b/_specials/_hinge.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(hinge) {
   0% {
     animation-timing-function: ease-in-out;

--- a/_specials/_rollIn.scss
+++ b/_specials/_rollIn.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(rollIn) {
   0% {
     opacity: 0;

--- a/_specials/_rollOut.scss
+++ b/_specials/_rollOut.scss
@@ -1,4 +1,5 @@
 // originally authored by Nick Pettit - https://github.com/nickpettit/glide
+@use '../properties' as *;
 
 @include keyframes(rollOut) {
   0% {

--- a/_specials/specials.scss
+++ b/_specials/specials.scss
@@ -1,6 +1,5 @@
 // INDEX OF SPECIAL ANIMATIONS
 
-@import 
-  "_hinge",
-  "_rollIn",
-  "_rollOut";
+@forward "hinge";
+@forward "rollIn";
+@forward "rollOut";

--- a/_zooming-entrances/_zoomIn.scss
+++ b/_zooming-entrances/_zoomIn.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(zoomIn) {
   0% {
     opacity: 0;

--- a/_zooming-entrances/_zoomInDown.scss
+++ b/_zooming-entrances/_zoomInDown.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(zoomInDown) {
   0% {
     animation-timing-function: cubic-bezier(0.550, 0.055, 0.675, 0.190);

--- a/_zooming-entrances/_zoomInLeft.scss
+++ b/_zooming-entrances/_zoomInLeft.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(zoomInLeft) {
   0% {
     animation-timing-function: cubic-bezier(0.550, 0.055, 0.675, 0.190);

--- a/_zooming-entrances/_zoomInRight.scss
+++ b/_zooming-entrances/_zoomInRight.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(zoomInRight) {
   0% {
     animation-timing-function: cubic-bezier(0.550, 0.055, 0.675, 0.190);

--- a/_zooming-entrances/_zoomInUp.scss
+++ b/_zooming-entrances/_zoomInUp.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(zoomInUp) {
   0% {
     animation-timing-function: cubic-bezier(0.550, 0.055, 0.675, 0.190);

--- a/_zooming-entrances/zooming-entrances.scss
+++ b/_zooming-entrances/zooming-entrances.scss
@@ -1,9 +1,8 @@
 // INDEX OF ZOOMING ENTRANCES
 
-@import
-  "_zoomIn",
-  "_zoomInDown",
-  "_zoomInLeft",
-  "_zoomInRight",
-  "_zoomInUp";
+@forward "zoomIn";
+@forward "zoomInDown";
+@forward "zoomInLeft";
+@forward "zoomInRight";
+@forward "zoomInUp";
   

--- a/_zooming-exits/_zoomOut.scss
+++ b/_zooming-exits/_zoomOut.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(zoomOut) {
   0% {
     opacity: 1;

--- a/_zooming-exits/_zoomOutDown.scss
+++ b/_zooming-exits/_zoomOutDown.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(zoomOutDown) {
   40% {
     animation-timing-function: cubic-bezier(0.550, 0.055, 0.675, 0.190);

--- a/_zooming-exits/_zoomOutLeft.scss
+++ b/_zooming-exits/_zoomOutLeft.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(zoomOutLeft) {
   40% {
     opacity: 1;

--- a/_zooming-exits/_zoomOutRight.scss
+++ b/_zooming-exits/_zoomOutRight.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(zoomOutRight) {
   40% {
     opacity: 1;

--- a/_zooming-exits/_zoomOutUp.scss
+++ b/_zooming-exits/_zoomOutUp.scss
@@ -1,3 +1,5 @@
+@use '../properties' as *;
+
 @include keyframes(zoomOutUp) {
   40% {
     animation-timing-function: cubic-bezier(0.550, 0.055, 0.675, 0.190);

--- a/_zooming-exits/zooming-exits.scss
+++ b/_zooming-exits/zooming-exits.scss
@@ -1,9 +1,8 @@
 // INDEX OF ZOOMING EXITS
 
-@import
-  "_zoomOut",
-  "_zoomOutDown",
-  "_zoomOutLeft",
-  "_zoomOutRight",
-  "_zoomOutUp";
+@forward "zoomOut";
+@forward "zoomOutDown";
+@forward "zoomOutLeft";
+@forward "zoomOutRight";
+@forward "zoomOutUp";
   

--- a/animate.scss
+++ b/animate.scss
@@ -8,12 +8,8 @@
 //
 //-----------------------------------------------------------------------
 
-// Always required
-@import
-  "_properties";
-
 // Import the animations
-@import
+@forward
   "_attention-seekers/attention-seekers.scss",
   "_bouncing-entrances/bouncing-entrances.scss",
   "_bouncing-exits/bouncing-exits.scss",


### PR DESCRIPTION

@import is deprecated in favor of @use and @forward. This would require refactoring of the current layout. This is a patch for retrofitting the current layout for Dart Sass 1.80.0+